### PR TITLE
Add SVR baseline model

### DIFF
--- a/cybench/models/README.md
+++ b/cybench/models/README.md
@@ -10,12 +10,15 @@
 
     d. Random Forest model. Ramdom Forest from scikit-learn acts as a non-linear baseline with expert-designed features. Both `Ridge` and `RandomForestRegressor` can be passed to `SklearnModel` as the sklearn estimator without having to change other code. Hyperparameter optimization is possible by passing the search space to `fit` method and setting the `optimize_hyperparameters` flag to True.
 
-    e. XGBoost model. XGBoost (gradient boosting trees) provides a stronger non-linear baseline using the same expert-designed features and BaseSklearnModel pipeline, with hyperparameters tuned via grouped cross-validation.
+   e. SVR model: Support Vector Regression from scikit-learn acts as another non-linear baseline using the same expert-designed features and `BaseSklearnModel` pipeline, with hyperparameters tuned via grouped cross-validation. Both `SVRModel` and its residual variant `SVRRes` are available.
 
-    f. LSTM. An example LSTM model is included as a deep learning (RNN) or representation learning baseline.
 
-    g. InceptionTime. An example InceptionTime model is included as a deep learning (1D-CNN) or representation learning baseline.
+    f. XGBoost model. XGBoost (gradient boosting trees) provides a stronger non-linear baseline using the same expert-designed features and BaseSklearnModel pipeline, with hyperparameters tuned via grouped cross-validation.
 
-    h. Transformer. An example Transformer model is included as a deep learning (Transformer) or representation learning baseline.
+    g. LSTM. An example LSTM model is included as a deep learning (RNN) or representation learning baseline.
 
-    i. Residual models: All the models c-g have their residual modeling counterparts. Residual models subtract the prediction of a Linear Trend model from b and learn to predict or forecast the residual (i.e. yield - trend). The idea is to remove the location and time dependent component of yields. The seasonal predictors included in CY-Bench are likely to better forecast the year-to-year variability in yields  than yields themselves.
+    h. InceptionTime. An example InceptionTime model is included as a deep learning (1D-CNN) or representation learning baseline.
+
+    i. Transformer. An example Transformer model is included as a deep learning (Transformer) or representation learning baseline.
+
+    j. Residual models: All the models c-g have their residual modeling counterparts. Residual models subtract the prediction of a Linear Trend model from b and learn to predict or forecast the residual (i.e. yield - trend). The idea is to remove the location and time dependent component of yields. The seasonal predictors included in CY-Bench are likely to better forecast the year-to-year variability in yields  than yields themselves.

--- a/cybench/models/residual_models.py
+++ b/cybench/models/residual_models.py
@@ -7,6 +7,7 @@ from cybench.datasets.modified_dataset import ModifiedTargetsDataset
 from cybench.models.model import BaseModel
 from cybench.models.trend_models import TrendModel
 from cybench.models.sklearn_models import SklearnRidge, SklearnRandomForest
+from cybench.models.svr_model import SVRModel
 from cybench.models.xgboost_model import XGBoostModel
 from cybench.models.nn_models import (
     BaselineLSTM,
@@ -152,6 +153,12 @@ class RandomForestRes(ResidualModel):
     def __init__(self, feature_cols: list = None):
         """RandomForest model that predicts residuals from the trend."""
         super().__init__(SklearnRandomForest(feature_cols=feature_cols))
+
+
+class SVRRes(ResidualModel):
+    def __init__(self, **kwargs):
+        """SVR model that predicts residuals from the trend."""
+        super().__init__(SVRModel(**kwargs))
 
 
 class XGBoostRes(ResidualModel):

--- a/cybench/models/svr_model.py
+++ b/cybench/models/svr_model.py
@@ -1,0 +1,49 @@
+import logging
+from collections.abc import Iterable
+
+from sklearn.svm import SVR
+
+from cybench.models.sklearn_models import BaseSklearnModel
+from cybench.datasets.dataset import Dataset
+
+
+class SVRModel(BaseSklearnModel):
+    """Support Vector Regression baseline using the BaseSklearnModel feature pipeline."""
+
+    def __init__(self, feature_cols: list = None):
+        """
+        Args:
+            feature_cols (list, optional): If provided, use these columns directly.
+                If None, BaseSklearnModel will design features from the Dataset.
+        """
+        svr = SVR(
+            kernel="rbf",
+            C=1.0,
+            epsilon=0.1,
+        )
+
+        kwargs = {
+            "feature_cols": feature_cols,
+            "estimator": svr,
+        }
+
+        super().__init__(**kwargs)
+
+    def fit(
+        self,
+        train_dataset: Dataset,
+        **fit_params,
+    ) -> tuple:
+        """Fit the SVR model with a simple hyperparameter search.
+
+        Args:
+            train_dataset (Dataset): training dataset
+            **fit_params: Additional parameters passed to BaseSklearnModel.fit.
+        """
+        fit_params["optimize_hyperparameters"] = True
+        fit_params["param_space"] = {
+            "estimator__C": [0.1, 1.0, 10.0],
+            "estimator__epsilon": [0.01, 0.1, 0.5],
+        }
+
+        super().fit(train_dataset, **fit_params)

--- a/cybench/runs/results_plots.py
+++ b/cybench/runs/results_plots.py
@@ -361,6 +361,8 @@ if __name__ == "__main__":
         "LinearTrend": "Trend",
         "SklearnRidge": "Ridge",
         "SklearnRF": "RF",
+        "SVRModel": "SVR",
+        "SVRRes": "SVR-Res",
         "XGBoostModel": "XGB",
         "XGBoostRes": "XGB-Res",
     }

--- a/cybench/runs/run_benchmark.py
+++ b/cybench/runs/run_benchmark.py
@@ -24,6 +24,7 @@ from cybench.evaluation.eval import (
 from cybench.models.naive_models import AverageYieldModel
 from cybench.models.trend_models import TrendModel
 from cybench.models.sklearn_models import SklearnRidge, SklearnRandomForest
+from cybench.models.svr_model import SVRModel
 from cybench.models.xgboost_model import XGBoostModel
 from cybench.models.nn_models import (
     BaselineLSTM,
@@ -34,6 +35,7 @@ from cybench.models.nn_models import (
 from cybench.models.residual_models import (
     RidgeRes,
     RandomForestRes,
+    SVRRes,
     XGBoostRes,
     LSTMRes,
     InceptionTimeRes,
@@ -48,6 +50,8 @@ _BASELINE_MODEL_CONSTRUCTORS = {
     "RidgeRes": RidgeRes,
     "SklearnRF": SklearnRandomForest,
     "RFRes": RandomForestRes,
+    "SVRModel": SVRModel,
+    "SVRRes": SVRRes,
     "XGBoostModel": XGBoostModel,
     "XGBoostRes": XGBoostRes,
     "LSTM": BaselineLSTM,


### PR DESCRIPTION
### Summary

This PR adds a Support Vector Regression (SVR) baseline to CY-Bench, following the same structure as the existing scikit-learn baselines.

### Changes

- Added `SVRModel` in `cybench/models/svr_model.py`
  - Uses `sklearn.svm.SVR` with an RBF kernel (`C=1.0`, `epsilon=0.1`) as the base estimator.
  - Reuses the `BaseSklearnModel` feature pipeline (same design as `SklearnRidge` and `SklearnRF`).
  - Enables the internal hyperparameter search with a small parameter grid:
    - `estimator__C`: `[0.1, 1.0, 10.0]`
    - `estimator__epsilon`: `[0.01, 0.1, 0.5]`

- Added residual variant:
  - `SVRRes` in `cybench/models/residual_models.py`, wrapping `SVRModel` inside the existing `ResidualModel` logic.

- Registered the new models in the benchmark runner:
  - Imported `SVRModel` and `SVRRes` in `cybench/runs/run_benchmark.py`.
  - Exposed them in `_BASELINE_MODEL_CONSTRUCTORS` as `"SVRModel"` and `"SVRRes"` so they can be run as standard baselines.

- Updated plotting utilities:
  - Extended `model_short_names` in `cybench/runs/results_plots.py` with:
    - `"SVRModel": "SVR"`
    - `"SVRRes": "SVR-Res"`

### Notes

- The implementation mirrors the pattern used for `SklearnRandomForest` and `XGBoostModel`, so SVR shares the same feature engineering and evaluation pipeline.
- No additional dependencies are introduced; SVR is part of the existing `scikit-learn` dependency.

### Checklist

- [x] Added `SVRModel` with `BaseSklearnModel` feature pipeline
- [x] Added `SVRRes` residual wrapper
- [x] Registered models in `run_benchmark.py`
- [x] Added short names in `results_plots.py`
- [x] Updated model docs if you prefer to list SVR explicitly

[Closes #378.](https://github.com/WUR-AI/AgML-CY-Bench/issues/376)